### PR TITLE
fix(extract): populate full registry via static index (lazy-import regression)

### DIFF
--- a/extract.py
+++ b/extract.py
@@ -510,12 +510,42 @@ def main():  # pylint: disable=too-many-locals,too-many-statements
     # These imports must happen inside main(): zetta_utils is only importable
     # in the user's active venv, and importing it eagerly would force loading
     # the heavy ML stack before we're ready to measure it.
+    import importlib  # pylint: disable=import-outside-toplevel
+
     import zetta_utils  # pylint: disable=import-outside-toplevel
     from zetta_utils.builder.registry import (  # pylint: disable=import-outside-toplevel
         REGISTRY,
     )
+    from zetta_utils.builder.scan import get_index  # pylint: disable=import-outside-toplevel
 
+    # Subpackages expose their builders through lazy __init__.py exports, so a
+    # bundle import (load_all_modules) binds the subpackage names without ever
+    # running the leaf modules whose @builder.register decorators populate
+    # REGISTRY — it lands only the always-eager handful. To materialize the full
+    # registry we walk the static index, which AST-discovers every module that
+    # registers a builder, and import them all.
     zetta_utils.load_all_modules()
+    missing_deps: list[str] = []
+    broken: list[tuple[str, str]] = []
+    for module in sorted({e.module for e in get_index().entries}):
+        try:
+            importlib.import_module(module)
+        except ModuleNotFoundError as exc:
+            # An absent third-party package (the optional pychunkedgraph extra,
+            # or a dep simply not installed in this venv) means those builders
+            # can't be introspected — degrade and emit the rest. A missing
+            # zetta_utils.* module is our own breakage, not a dependency gap, so
+            # route it to `broken` instead.
+            if (exc.name or "").split(".")[0] == "zetta_utils":
+                broken.append((module, f"{type(exc).__name__}: {exc}"))
+            else:
+                missing_deps.append(module)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            # A registration collision, syntax error, or bad import in our own
+            # code aborts the whole module import and drops ALL its builders.
+            # Record it so the run can fail loudly rather than ship a silently
+            # incomplete schema.
+            broken.append((module, f"{type(exc).__name__}: {exc}"))
     t1 = time.perf_counter()
 
     zu_pkg_dir = Path(zetta_utils.__file__).parent
@@ -621,8 +651,25 @@ def main():  # pylint: disable=too-many-locals,too-many-statements
     )
     if removed:
         print(f"removed stale:    {len(removed)} older cache dir(s)", file=sys.stderr)
+    if missing_deps:
+        print(
+            f"skipped modules:  {len(missing_deps)} (deps not installed in this venv)",
+            file=sys.stderr,
+        )
+    if broken:
+        print(
+            f"UNEXPECTED import failures: {len(broken)} module(s) — schema is incomplete",
+            file=sys.stderr,
+        )
+        for module, err in broken:
+            print(f"  {module}: {err}", file=sys.stderr)
     # Print cache dir to stdout so tools can capture it.
     print(str(cache_dir))
+    if broken:
+        # Exit non-zero so the failure surfaces through the extension's error
+        # path (it shows the tail of stderr) and in CI, instead of passing as a
+        # successful run with a quietly incomplete schema.
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zetta-cue",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zetta-cue",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@types/node": "^20.0.0",
         "@types/vscode": "^1.85.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zetta-cue",
   "displayName": "Zetta CUE",
   "description": "Hover and validation for zetta_utils builder specs in CUE.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "zettaai",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
## Problem

`zetta_utils` recently moved its subpackage `__init__.py` exports to lazy
resolution (`make_lazy_module`, PEP 562). `extract.py` relied on
`zetta_utils.load_all_modules()` to populate the builder `REGISTRY`, but that
now only runs the always-eager handful of modules — the lazy subpackages bind
their names without ever executing the leaf modules whose `@builder.register`
decorators do the registration.

Result: the generated schema dropped from **477** builders to **77**, so
hover, validation, and go-to-def silently lost ~84% of `@type`s.

## Fix

Walk the static index (`zetta_utils.builder.scan.get_index()`, which
AST-discovers every module that registers a builder) and `importlib`-import
them all, materializing the full `REGISTRY` before introspection.

Verified: **77 → 477 names / 487 entries**; `cue vet` passes on the generated
`schemas.cue`; the 170 `imgaug.augmenters.*` f-string-registered builders are
included (their module has a literal `@register` anchor, so it's in the index).

## Import-failure handling

Rather than swallowing every exception and labeling all of them "unmet optional
deps", failures are now classified:

- a **missing third-party dependency** (e.g. the optional `pychunkedgraph`
  extra, or a dep absent from the user's venv) degrades gracefully — those
  builders are skipped and the rest still emit;
- a **broken `zetta_utils` module** or a **registration collision** fails loudly
  with a non-zero exit, so a regression that drops a whole module's builders
  surfaces through the extension's error path and in CI instead of shipping a
  quietly incomplete schema.

Bumps the extension to **0.1.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)