### PR TITLE
fix(regenerate): surface spawn failures instead of hanging forever

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -557,10 +557,29 @@ async function regenerate(context: vscode.ExtensionContext) {
       const child = cp.spawn(pythonPath, [extractorPath], { timeout: 120000 });
       let stderr = "";
       child.stderr.on("data", (d) => (stderr += d.toString()));
+      // Drain stdout: a chatty import-time banner could otherwise fill the pipe
+      // buffer and block the child forever. The cache dir is found on disk by
+      // mtime, so the extractor's stdout is not needed here.
+      child.stdout?.on("data", () => {});
+      // A spawn failure (missing or stale interpreter path → ENOENT) emits
+      // 'error' and never 'close'; without this listener the progress promise
+      // would hang indefinitely instead of surfacing the problem.
+      child.on("error", (err) => {
+        vscode.window.showErrorMessage(
+          `Zetta CUE: could not run Python '${pythonPath}': ${err.message}. ` +
+          `Set 'zettaCue.pythonPath' to a Python interpreter with zetta_utils installed.`,
+        );
+        reject(err);
+      });
       child.on("close", (code) => {
         if (code === 0) { vscode.window.showInformationMessage("Zetta CUE: metadata refreshed."); resolve(); }
         else {
-          vscode.window.showErrorMessage(`Zetta CUE: extractor exited ${code}. Last stderr:\n${stderr.split("\n").slice(-8).join("\n")}`);
+          const hint = /No module named ['"]?zetta_utils/.test(stderr)
+            ? "\n\nThis interpreter can't import zetta_utils — set 'zettaCue.pythonPath' to the venv that has it."
+            : "";
+          vscode.window.showErrorMessage(
+            `Zetta CUE: extractor exited ${code}. Last stderr:\n${stderr.split("\n").slice(-8).join("\n")}${hint}`,
+          );
           reject(new Error(`extractor exit ${code}`));
         }
       });


### PR DESCRIPTION
## Problem

`regenerate()` attached a listener only to `child.stderr` and `child.on("close")`. If the spawn itself fails — e.g. `zettaCue.pythonPath` is unset and the fallback interpreter path is missing/stale → `ENOENT` — Node emits `'error'` and never `'close'`. With no `'error'` listener the progress promise never settles, so **"Regenerating metadata…" hangs forever** with no indication of what went wrong. (`child.stdout` was also never drained — a >64KB import-time banner would deadlock the pipe.)

## Fix

- add `child.on("error", …)` → reject with a clear message pointing at `zettaCue.pythonPath`
- drain `child.stdout` (the cache dir is found on disk by mtime, not read from stdout)
- on a non-zero exit whose stderr shows `No module named zetta_utils`, hint to set `zettaCue.pythonPath` to the venv that has it

No `extract.py` change, so the metadata cache key is unchanged (no forced regen). Version stays **0.1.1** — this is a same-day follow-up to the 0.1.1 release; the asset will be re-uploaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)