### PR TITLE
Cache inside repo + fix PEP 604 union types (v0.1.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,11 @@ vscode_zutils/
 └── README.md               This file
 ```
 
-Generated metadata lives in `~/.cache/zetta-utils-vscode/<content-hash>/`
-(never committed). Stale cache dirs beyond the 3 most recent are cleaned up
-on each regeneration.
+Generated metadata lives in `<workspace>/.zetta_cue_cache/<content-hash>/`
+(gitignored). The location can be overridden with `$ZETTA_CUE_CACHE_DIR`, which
+the extension sets to the open workspace so the Claude Code lint hook shares the
+same cache. Stale cache dirs beyond the 3 most recent are cleaned up on each
+regeneration.
 
 ## Design notes
 

--- a/extract.py
+++ b/extract.py
@@ -13,13 +13,14 @@ from __future__ import annotations
 import hashlib
 import inspect
 import json
+import os
 import re
 import shutil
 import sys
 import time
 import typing
 from pathlib import Path
-from types import NoneType
+from types import NoneType, UnionType
 from typing import Any, get_args, get_origin
 
 # ─────────────────────────────────────────────────────────────
@@ -60,10 +61,12 @@ def _cache_key(zu_dir: Path) -> str:
 
 def _cleanup_old_caches(cache_root: Path, keep: str, keep_n: int = 3) -> list[str]:
     """Remove all cache dirs except the `keep_n` most recently modified,
-    always including the `keep` dir itself. Returns names that were removed."""
+    always including the `keep` dir itself. The `bin/` dir (the provisioned
+    parser binary) is never a cache and is always preserved. Returns names that
+    were removed."""
     if not cache_root.exists():
         return []
-    entries = [p for p in cache_root.iterdir() if p.is_dir()]
+    entries = [p for p in cache_root.iterdir() if p.is_dir() and p.name != "bin"]
     # Order by mtime, newest first
     entries.sort(key=lambda p: p.stat().st_mtime, reverse=True)
     to_keep: set[str] = {keep}
@@ -79,6 +82,20 @@ def _cleanup_old_caches(cache_root: Path, keep: str, keep_n: int = 3) -> list[st
         except OSError:
             pass
     return removed
+
+
+def _cache_root(zu_pkg_dir: Path) -> Path:
+    """Root holding the per-hash schema caches (`<key>/`) and the parser bin.
+
+    Honors $ZETTA_CUE_CACHE_DIR so the VS Code extension and the Claude Code
+    lint hook can all agree on one location; otherwise defaults to a gitignored
+    `.zetta_cue_cache/` beside the zetta_utils package — i.e. the repo root for
+    an editable checkout.
+    """
+    override = os.environ.get("ZETTA_CUE_CACHE_DIR")
+    if override:
+        return Path(override)
+    return zu_pkg_dir.parent / ".zetta_cue_cache"
 
 
 # ─────────────────────────────────────────────────────────────
@@ -112,7 +129,7 @@ def _cue_type(annotation: Any) -> str:  # pylint: disable=too-many-return-statem
     if origin is typing.Literal:
         return " | ".join(_cue_literal(a) for a in args)
 
-    if origin is typing.Union:
+    if origin is typing.Union or origin is UnionType:
         non_none = [a for a in args if a is not NoneType]
         cue = " | ".join(_cue_type(a) for a in non_none)
         if NoneType in args:
@@ -551,7 +568,7 @@ def main():  # pylint: disable=too-many-locals,too-many-statements
     zu_pkg_dir = Path(zetta_utils.__file__).parent
     key = _cache_key(zu_pkg_dir)
 
-    cache_dir = Path.home() / ".cache" / "zetta-utils-vscode" / key
+    cache_dir = _cache_root(zu_pkg_dir) / key
     cache_dir.mkdir(parents=True, exist_ok=True)
 
     # Dynamic resolvers (np.*, torch.*) handle name families computed at build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zetta-cue",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zetta-cue",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
         "@types/node": "^20.0.0",
         "@types/vscode": "^1.85.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zetta-cue",
   "displayName": "Zetta CUE",
   "description": "Hover and validation for zetta_utils builder specs in CUE.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publisher": "zettaai",
   "engines": {
     "vscode": "^1.85.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -232,7 +232,13 @@ function hashSourceTree(sourcePath: string, extractPyPath: string): string {
 // Metadata loading
 // ─────────────────────────────────────────────────────────────
 
-function cacheRoot(): string { return path.join(os.homedir(), ".cache", "zetta-utils-vscode"); }
+// Cache lives inside the workspace (gitignored) so it's co-located with the
+// repo and shared with the Claude Code lint hook via $ZETTA_CUE_CACHE_DIR.
+// Falls back to a home-level dir only when no folder is open.
+function cacheRoot(): string {
+  const ws = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  return ws ? path.join(ws, ".zetta_cue_cache") : path.join(os.homedir(), ".zetta_cue_cache");
+}
 
 async function findCacheDir(): Promise<string | null> {
   const root = cacheRoot();
@@ -683,7 +689,10 @@ async function regenerate(context: vscode.ExtensionContext) {
   return vscode.window.withProgress(
     { location: vscode.ProgressLocation.Notification, title: "Zetta CUE: Regenerating metadata…", cancellable: false },
     () => new Promise<void>((resolve, reject) => {
-      const child = cp.spawn(pythonPath, [extractorPath], { timeout: 120000 });
+      const child = cp.spawn(pythonPath, [extractorPath], {
+        timeout: 120000,
+        env: { ...process.env, ZETTA_CUE_CACHE_DIR: cacheRoot() },
+      });
       let stderr = "";
       child.stderr.on("data", (d) => (stderr += d.toString()));
       // Drain stdout: a chatty import-time banner could otherwise fill the pipe


### PR DESCRIPTION
## Cache relocation
Moves the generated schema cache **and** the parser bin out of `~/.cache/zetta-utils-vscode/` into a gitignored `.zetta_cue_cache/` inside the workspace.

- `extract.py` honors `$ZETTA_CUE_CACHE_DIR` (new `_cache_root()` helper), defaulting to `.zetta_cue_cache/` beside the `zetta_utils` package (repo root for an editable checkout).
- The extension sets `$ZETTA_CUE_CACHE_DIR` to the open workspace folder and reads from the same location, so it shares one cache with the Claude Code lint hook.
- `_cleanup_old_caches` never prunes the `bin/` dir.
- Drops "vscode" from the path name so the hook-only (no-editor) workflow isn't confusing.

## Type-generation fix
`_cue_type` only matched the legacy `typing.Union[...]` form, so PEP 604 `X | Y` annotations (`get_origin` → `types.UnionType`) fell through to the conservative `_` fallback. Now both forms are handled.

Concretely, `sigma: float | None` in `nanmedian_filter` was generating `sigma?: _`; it now generates `sigma?: number | null`. `number` is the correct CUE type — it accepts both int and float literals, unlike bare `float` (which rejects integer literals like `3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)